### PR TITLE
feat: Add output transformation to IsDate

### DIFF
--- a/src/decorators/is-date.spec.ts
+++ b/src/decorators/is-date.spec.ts
@@ -11,7 +11,7 @@ describe('IsDate', () => {
     }
 
     class TestDateOutput {
-      @IsDate({ format: 'date', optional: true, serialize: true })
+      @IsDate({ format: 'date', optional: true, formatOutput: true })
       date?: Date;
     }
 
@@ -21,7 +21,7 @@ describe('IsDate', () => {
     }
 
     class TestDateTimeOutput {
-      @IsDate({ format: 'date', optional: true, serialize: true })
+      @IsDate({ format: 'date', optional: true, formatOutput: true })
       date?: Date;
     }
 
@@ -73,7 +73,7 @@ describe('IsDate', () => {
 
       describe('output', () => {
         class TestOutput {
-          @IsDate({ format: 'date', serialize: true })
+          @IsDate({ format: 'date', formatOutput: true })
           date!: Date;
         }
 
@@ -127,7 +127,7 @@ describe('IsDate', () => {
 
       describe('output', () => {
         class TestOutput {
-          @IsDate({ format: 'date-time', serialize: true })
+          @IsDate({ format: 'date-time', formatOutput: true })
           date!: Date;
         }
 

--- a/src/decorators/is-date.spec.ts
+++ b/src/decorators/is-date.spec.ts
@@ -1,114 +1,147 @@
 import { Result } from 'true-myth';
 
-import { input, make, output } from '../../tests/helpers';
+import { input, make, output, outputValidate } from '../../tests/helpers';
 import { IsDate } from '../nestjs-swagger-dto';
 
 describe('IsDate', () => {
-  describe('single date', () => {
-    class Test {
-      @IsDate({ format: 'date' })
-      date!: Date;
+  describe('date is optional', () => {
+    class TestDateInput {
+      @IsDate({ format: 'date', optional: true })
+      date?: Date;
     }
 
-    class TestSerialize {
-      @IsDate({ format: 'date', serialize: true })
-      date!: Date;
+    class TestDateOutput {
+      @IsDate({ format: 'date', optional: true, serialize: true })
+      date?: Date;
     }
 
-    it('accepts date', async () => {
-      expect(await input(Test, { date: '2011-12-30' })).toStrictEqual(
-        Result.ok(make(Test, { date: new Date('2011-12-30') }))
-      );
+    class TestDateTimeInput {
+      @IsDate({ format: 'date', optional: true })
+      date?: Date;
+    }
+
+    class TestDateTimeOutput {
+      @IsDate({ format: 'date', optional: true, serialize: true })
+      date?: Date;
+    }
+
+    it('pass through when no date is set on input', async () => {
+      expect(await input(TestDateInput, {})).toStrictEqual(Result.ok(new TestDateInput()));
+      expect(await input(TestDateTimeInput, {})).toStrictEqual(Result.ok(new TestDateTimeInput()));
     });
 
-    it('rejects invalid date', async () => {
-      expect(await input(Test, { date: '2011-13-13' })).toStrictEqual(
-        Result.err('date is not a valid Date')
-      );
-
-      expect(await input(Test, { date: 'not a date' })).toStrictEqual(
-        Result.err('date is not formatted as `yyyy-mm-dd`')
-      );
-
-      expect(await input(Test, { date: '2011/12/02' })).toStrictEqual(
-        Result.err('date is not formatted as `yyyy-mm-dd`')
-      );
-    });
-
-    it('transforms to date formatted string', async () => {
-      const dateToUse = new Date();
-      const obj = new TestSerialize();
-      obj.date = dateToUse;
-
-      expect(await output(obj)).toStrictEqual({ date: dateToUse.toISOString().slice(0, 10) });
-    });
-
-    it('pass through when field is undefined', async () => {
-      const obj = new TestSerialize();
-
-      expect(await output(obj)).toStrictEqual({});
-    });
-
-    it('pass through value if no serialize', async () => {
-      const dateToUse = new Date();
-      const obj = new Test();
-      obj.date = dateToUse;
-
-      expect(await output(obj)).toStrictEqual({ date: dateToUse });
+    it('pass through if no date is set on output', async () => {
+      expect(output(make(TestDateOutput, {}))).toStrictEqual({});
+      expect(output(make(TestDateTimeOutput, {}))).toStrictEqual({});
     });
   });
 
-  describe('single date-time', () => {
-    class Test {
-      @IsDate({ format: 'date-time' })
-      date?: Date;
-    }
+  describe('date is mandatory', () => {
+    describe('single date', () => {
+      describe('input', () => {
+        class TestInput {
+          @IsDate({ format: 'date' })
+          date!: Date;
+        }
 
-    class TestSerialize {
-      @IsDate({ format: 'date-time', serialize: true })
-      date?: Date;
-    }
+        it('accepts date', async () => {
+          expect(await input(TestInput, { date: '2011-12-30' })).toStrictEqual(
+            Result.ok(make(TestInput, { date: new Date('2011-12-30') }))
+          );
+        });
 
-    it('accepts date-time', async () => {
-      expect(await input(Test, { date: '2017-06-01T18:43:26.000Z' })).toStrictEqual(
-        Result.ok(make(Test, { date: new Date('2017-06-01T18:43:26.000Z') }))
-      );
+        it('rejects invalid date', async () => {
+          expect(await input(TestInput, { date: '2011-13-13' })).toStrictEqual(
+            Result.err('date is not a valid Date')
+          );
+
+          expect(await input(TestInput, { date: 'not a date' })).toStrictEqual(
+            Result.err('date is not formatted as `yyyy-mm-dd`')
+          );
+
+          expect(await input(TestInput, { date: '2011/12/02' })).toStrictEqual(
+            Result.err('date is not formatted as `yyyy-mm-dd`')
+          );
+        });
+
+        it('pass through value if no serialize', async () => {
+          const date = new Date();
+
+          expect(output(make(TestInput, { date }))).toStrictEqual({ date: date });
+        });
+      });
+
+      describe('output', () => {
+        class TestOutput {
+          @IsDate({ format: 'date', serialize: true })
+          date!: Date;
+        }
+
+        it('rejects output if no date is set', async () => {
+          expect(await outputValidate(new TestOutput())).toStrictEqual(
+            Result.err('an unknown value was passed to the validate function')
+          );
+        });
+
+        it('transforms to date formatted string', async () => {
+          const date = new Date();
+          expect(output(make(TestOutput, { date }))).toStrictEqual({
+            date: date.toISOString().slice(0, 10),
+          });
+        });
+      });
     });
 
-    it('rejects invalid date-time', async () => {
-      expect(await input(Test, { date: '2011-13-13' })).toStrictEqual(
-        Result.err('date is not ISO8601 format')
-      );
+    describe('single date-time', () => {
+      describe('input', () => {
+        class Test {
+          @IsDate({ format: 'date-time' })
+          date!: Date;
+        }
 
-      expect(await input(Test, { date: 'not a date' })).toStrictEqual(
-        Result.err('date is not ISO8601 format')
-      );
+        it('accepts date-time', async () => {
+          expect(await input(Test, { date: '2017-06-01T18:43:26.000Z' })).toStrictEqual(
+            Result.ok(make(Test, { date: new Date('2017-06-01T18:43:26.000Z') }))
+          );
+        });
 
-      expect(await input(Test, { date: '2011/12/02' })).toStrictEqual(
-        Result.err('date is not ISO8601 format')
-      );
-    });
+        it('rejects invalid date-time', async () => {
+          expect(await input(Test, { date: '2011-13-13' })).toStrictEqual(
+            Result.err('date is not ISO8601 format')
+          );
 
-    it('transforms to ISO formatted string', async () => {
-      const dateToUse = new Date();
-      const obj = new TestSerialize();
-      obj.date = dateToUse;
+          expect(await input(Test, { date: 'not a date' })).toStrictEqual(
+            Result.err('date is not ISO8601 format')
+          );
 
-      expect(await output(obj)).toStrictEqual({ date: dateToUse.toISOString() });
-    });
+          expect(await input(Test, { date: '2011/12/02' })).toStrictEqual(
+            Result.err('date is not ISO8601 format')
+          );
+        });
 
-    it('pass through when field is undefined', async () => {
-      const obj = new TestSerialize();
+        it('pass through value if no serialize', async () => {
+          const date = new Date();
+          expect(output(make(Test, { date }))).toStrictEqual({ date });
+        });
+      });
 
-      expect(await output(obj)).toStrictEqual({});
-    });
+      describe('output', () => {
+        class TestOutput {
+          @IsDate({ format: 'date-time', serialize: true })
+          date!: Date;
+        }
 
-    it('pass through value if no serialize', async () => {
-      const dateToUse = new Date();
-      const obj = new Test();
-      obj.date = dateToUse;
+        it('rejects output if no date is set', async () => {
+          expect(await outputValidate(new TestOutput())).toStrictEqual(
+            Result.err('an unknown value was passed to the validate function')
+          );
+        });
 
-      expect(await output(obj)).toStrictEqual({ date: dateToUse });
+        it('transforms to ISO formatted string', async () => {
+          const date = new Date();
+          expect(output(make(TestOutput, { date }))).toStrictEqual({ date: date.toISOString() });
+        });
+      });
     });
   });
 });

--- a/src/decorators/is-date.spec.ts
+++ b/src/decorators/is-date.spec.ts
@@ -1,12 +1,17 @@
 import { Result } from 'true-myth';
 
-import { input, make } from '../../tests/helpers';
+import { input, make, output } from '../../tests/helpers';
 import { IsDate } from '../nestjs-swagger-dto';
 
 describe('IsDate', () => {
   describe('single date', () => {
     class Test {
       @IsDate({ format: 'date' })
+      date!: Date;
+    }
+
+    class TestSerialize {
+      @IsDate({ format: 'date', serialize: true })
       date!: Date;
     }
 
@@ -29,12 +34,39 @@ describe('IsDate', () => {
         Result.err('date is not formatted as `yyyy-mm-dd`')
       );
     });
+
+    it('transforms to date formatted string', async () => {
+      const dateToUse = new Date();
+      const obj = new TestSerialize();
+      obj.date = dateToUse;
+
+      expect(await output(obj)).toStrictEqual({ date: dateToUse.toISOString().slice(0, 10) });
+    });
+
+    it('pass through when field is undefined', async () => {
+      const obj = new TestSerialize();
+
+      expect(await output(obj)).toStrictEqual({});
+    });
+
+    it('pass through value if no serialize', async () => {
+      const dateToUse = new Date();
+      const obj = new Test();
+      obj.date = dateToUse;
+
+      expect(await output(obj)).toStrictEqual({ date: dateToUse });
+    });
   });
 
   describe('single date-time', () => {
     class Test {
       @IsDate({ format: 'date-time' })
-      date!: Date;
+      date?: Date;
+    }
+
+    class TestSerialize {
+      @IsDate({ format: 'date-time', serialize: true })
+      date?: Date;
     }
 
     it('accepts date-time', async () => {
@@ -55,6 +87,28 @@ describe('IsDate', () => {
       expect(await input(Test, { date: '2011/12/02' })).toStrictEqual(
         Result.err('date is not ISO8601 format')
       );
+    });
+
+    it('transforms to ISO formatted string', async () => {
+      const dateToUse = new Date();
+      const obj = new TestSerialize();
+      obj.date = dateToUse;
+
+      expect(await output(obj)).toStrictEqual({ date: dateToUse.toISOString() });
+    });
+
+    it('pass through when field is undefined', async () => {
+      const obj = new TestSerialize();
+
+      expect(await output(obj)).toStrictEqual({});
+    });
+
+    it('pass through value if no serialize', async () => {
+      const dateToUse = new Date();
+      const obj = new Test();
+      obj.date = dateToUse;
+
+      expect(await output(obj)).toStrictEqual({ date: dateToUse });
     });
   });
 });

--- a/src/decorators/is-date.ts
+++ b/src/decorators/is-date.ts
@@ -1,37 +1,72 @@
-import { Transform } from 'class-transformer';
+import { Transform, TransformFnParams, TransformOptions } from 'class-transformer';
 import { IsDate as IsDateCV, isDateString } from 'class-validator';
 
 import { compose, PropertyOptions } from '../core';
 
 const crudeDateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
+function TransformDate({ key, value }: TransformFnParams): Date | Error {
+  if (!crudeDateRegex.test(value)) {
+    return new Error(`${key} is not formatted as \`yyyy-mm-dd\``);
+  }
+
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return new Error(`${key} is not a valid Date`);
+  }
+
+  return date;
+}
+
+function TransformDateTime({ key, value }: TransformFnParams): Date | Error {
+  if (!isDateString(value, { strict: true })) {
+    return new Error(`${key} is not ISO8601 format`);
+  }
+
+  return new Date(value);
+}
+
+type TransformFn = (params: TransformFnParams) => any;
+
+function TransformToClass(transformFn: TransformFn, options?: TransformOptions): PropertyDecorator {
+  return Transform(transformFn, { ...options, toClassOnly: true });
+}
+
+function TransformToPlain(transformFn: TransformFn, options?: TransformOptions): PropertyDecorator {
+  return Transform(transformFn, { ...options, toPlainOnly: true });
+}
+
+const isDate = (format: 'date' | 'date-time') => format === 'date';
+
 // TODO: array support
+/***
+ * Date-decorator used for deserializing and serializing dates.
+ * @param format Either 'date' or 'date-time'. The value determines what kind of validations and transformations to apply.
+ * @param serialize If not set, only input is transformed. If set to `true`, output is a date or date-time formatted string.
+ * @param base
+ * @constructor
+ */
 export const IsDate = ({
   format,
+  serialize,
   ...base
-}: Omit<PropertyOptions<Date, { format: 'date' | 'date-time' }>, 'isArray'>): PropertyDecorator =>
-  compose(
+}: Omit<
+  PropertyOptions<Date, { format: 'date' | 'date-time'; serialize?: true }>,
+  'isArray'
+>): PropertyDecorator => {
+  return compose(
     { type: 'string', format },
     base,
-    format === 'date'
-      ? Transform(({ key, value }) => {
-          if (!crudeDateRegex.test(value)) {
-            return new Error(`${key} is not formatted as \`yyyy-mm-dd\``);
-          }
+    TransformToClass((params) =>
+      isDate(format) ? TransformDate(params) : TransformDateTime(params)
+    ),
+    TransformToPlain(({ value }) => {
+      if (!serialize) return value;
 
-          const date = new Date(value);
-          if (isNaN(date.getTime())) {
-            return new Error(`${key} is not a valid Date`);
-          }
+      if (!value) return undefined;
 
-          return date;
-        })
-      : Transform(({ key, value }) => {
-          if (!isDateString(value, { strict: true })) {
-            return new Error(`${key} is not ISO8601 format`);
-          }
-
-          return new Date(value);
-        }),
+      return isDate(format) ? value.toISOString().slice(0, 10) : value.toISOString();
+    }),
     IsDateCV({ message: ({ value }) => value.message })
   );
+};

--- a/src/decorators/is-date.ts
+++ b/src/decorators/is-date.ts
@@ -57,15 +57,18 @@ export const IsDate = ({
   return compose(
     { type: 'string', format },
     base,
-    TransformToClass((params) =>
-      isDate(format) ? TransformDate(params) : TransformDateTime(params)
-    ),
+    TransformToClass((params) => {
+      if (base.optional && !params.value) return undefined;
+
+      return isDate(format) ? TransformDate(params) : TransformDateTime(params);
+    }),
     TransformToPlain(({ value }) => {
       if (!serialize) return value;
 
       if (!value) return undefined;
 
-      return isDate(format) ? value.toISOString().slice(0, 10) : value.toISOString();
+      const isoDate = value.toISOString();
+      return isDate(format) ? isoDate.slice(0, 10) : isoDate;
     }),
     IsDateCV({ message: ({ value }) => value.message })
   );

--- a/src/decorators/is-date.ts
+++ b/src/decorators/is-date.ts
@@ -42,16 +42,16 @@ const isDate = (format: 'date' | 'date-time') => format === 'date';
 /***
  * Date-decorator used for deserializing and serializing dates.
  * @param format Either 'date' or 'date-time'. The value determines what kind of validations and transformations to apply.
- * @param serialize If not set, only input is transformed. If set to `true`, output is a date or date-time formatted string.
+ * @param formatOutput If not set, only input is transformed. If set to `true`, output is a date or date-time formatted string depending on format
  * @param base
  * @constructor
  */
 export const IsDate = ({
   format,
-  serialize,
+  formatOutput,
   ...base
 }: Omit<
-  PropertyOptions<Date, { format: 'date' | 'date-time'; serialize?: true }>,
+  PropertyOptions<Date, { format: 'date' | 'date-time'; formatOutput?: true }>,
   'isArray'
 >): PropertyDecorator => {
   return compose(
@@ -63,7 +63,7 @@ export const IsDate = ({
       return isDate(format) ? TransformDate(params) : TransformDateTime(params);
     }),
     TransformToPlain(({ value }) => {
-      if (!serialize) return value;
+      if (!formatOutput) return value;
 
       if (!value) return undefined;
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -35,6 +35,19 @@ export function output<T>(instance: T): T {
   }) as T;
 }
 
+export async function outputValidate<T extends Record<string, any>>(
+  instance: T
+): Promise<Result<T, string>> {
+  const res: T = output(instance);
+  const errors = await validate(res, {
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    forbidUnknownValues: true,
+  });
+
+  return errors.length === 0 ? Result.ok(res) : Result.err(getValidationError(errors[0]));
+}
+
 function getValidationError(error: ValidationError): string {
   return error.constraints
     ? Object.values(error.constraints)[0]


### PR DESCRIPTION
Added a serialization property to IsDate to allow for transforming Dates to string in correct format.
If `format='date'` the output is a date formatted string, on the format `yyyy-mm-dd`.
If `format='date-time'` the output is a ISO formatted date-time string