### PR TITLE
fix(is-enum-array): fix the problem, runtime error when passing isArray to IsEnum decorator

### DIFF
--- a/src/decorators/is-enum.ts
+++ b/src/decorators/is-enum.ts
@@ -1,3 +1,4 @@
+import { getSchemaPath } from '@nestjs/swagger';
 import { IsIn } from 'class-validator';
 
 import { compose, PropertyOptions } from '../core';
@@ -18,10 +19,19 @@ export const IsEnum = <T extends number | string>({
   enum: enumOptions,
   ...base
 }: PropertyOptions<T, { enum: EnumOptions<T> }>): PropertyDecorator => {
-  const { enumValues, enumName } = getEnumNameAndValues(enumOptions);
+  const { enumName, enumValues } = getEnumNameAndValues(enumOptions);
+
+  const enumNameOptions =
+    base.isArray && enumName
+      ? {
+          items: {
+            $ref: getSchemaPath(enumName),
+          },
+        }
+      : { enumName };
 
   return compose(
-    { type: typeof enumValues[0], enum: enumValues, enumName },
+    { type: base.isArray ? 'array' : typeof enumValues[0], enum: enumValues, ...enumNameOptions },
     base,
     IsIn(enumValues, { each: !!base.isArray })
   );


### PR DESCRIPTION
I have found a possible problem(at least, locally everything works for me), i have discovered, that when we pass isArray to IsEnum decorator, in previous implementation we where passing to ApiPropertyOptional property enumName, but, it does not work with arrays, @nestjs/swagger tries to find by enumName in array of all schemas, but never finds it, so i removed enumName when isArray is true, and added items object to options